### PR TITLE
fix modified columns on updateProductLabel

### DIFF
--- a/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelEntityManager.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelEntityManager.php
@@ -65,9 +65,12 @@ class ProductLabelEntityManager extends AbstractEntityManager implements Product
             $productLabelTransfer,
             $productLabelEntity,
         );
+        
+        $modifiedColumns = $productLabelEntity->getModifiedColumns();
+
         $productLabelEntity->save();
 
-        return $productLabelEntity->getModifiedColumns();
+        return $modifiedColumns;
     }
 
     /**


### PR DESCRIPTION
## PR Description

After saving the entity the modified columns are reset and the return value is always an empty array.
The consequence is that activating or deactivating a label won't touch dictionary and products.


## Checklist
- [ x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
