### PR TITLE
SUPESC-667 Backport for get product label collection.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "spryker/storage": "^3.0.0",
     "spryker/symfony": "^3.0.0",
     "spryker/touch": "^3.1.0 || ^4.0.0",
+    "spryker/transfer": "^3.27.0",
     "spryker/twig": "^3.0.0"
   },
   "require-dev": {

--- a/dependency.json
+++ b/dependency.json
@@ -1,0 +1,5 @@
+{
+    "include": {
+        "spryker/transfer": "Provides transfer objects definition with strict types and `::get*OrFail()` functionality."
+    }
+}

--- a/src/Spryker/Shared/ProductLabel/Transfer/product_label.transfer.xml
+++ b/src/Spryker/Shared/ProductLabel/Transfer/product_label.transfer.xml
@@ -71,13 +71,12 @@
     </transfer>
 
     <transfer name="ProductLabelCriteria">
-        <property name="productAbstractIds" type="int[]" singular="productAbstractId"/>
+        <property name="productLabelConditions" type="ProductLabelConditions" strict="true"/>
         <property name="productLabelIds" type="int[]" singular="productLabelId"/>
         <property name="pagination" type="Pagination" strict="true"/>
-        <property name="sortCollection" type="Sort[]" singular="sort"/>
+        <property name="sortCollection" type="Sort[]" singular="sort" strict="true"/>
         <property name="withProductLabelLocalizedAttributes" type="bool"/>
         <property name="withProductLabelProductAbstracts" type="bool"/>
-        <property name="isActive" type="bool"/>
     </transfer>
 
     <transfer name="ProductLabelCollection" strict="true">
@@ -97,6 +96,11 @@
     <transfer name="Sort">
         <property name="field" type="string"/>
         <property name="isAscending" type="bool"/>
+    </transfer>
+
+    <transfer name="ProductLabelConditions" strict="true">
+        <property name="productAbstractIds" type="int[]" singular="productAbstractId"/>
+        <property name="isActive" type="bool"/>
     </transfer>
 
 </transfers>

--- a/src/Spryker/Shared/ProductLabel/Transfer/product_label.transfer.xml
+++ b/src/Spryker/Shared/ProductLabel/Transfer/product_label.transfer.xml
@@ -21,6 +21,7 @@
             singular="localizedAttributes"
             type="ProductLabelLocalizedAttributes[]"
         />
+        <property name="productLabelProductAbstracts" type="ProductLabelProductAbstract[]" singular="productLabelProductAbstract"/>
     </transfer>
 
     <transfer name="ProductLabelLocalizedAttributes">
@@ -61,6 +62,41 @@
     <transfer name="Message">
         <property name="value" type="string"/>
         <property name="parameters" type="array" singular="parameters"/>
+    </transfer>
+
+    <transfer name="ProductLabelProductAbstract">
+        <property name="idProductLabelProductAbstract" type="int"/>
+        <property name="fkProductAbstract" type="int"/>
+        <property name="fkProductLabel" type="int"/>
+    </transfer>
+
+    <transfer name="ProductLabelCriteria">
+        <property name="productAbstractIds" type="int[]" singular="productAbstractId"/>
+        <property name="productLabelIds" type="int[]" singular="productLabelId"/>
+        <property name="pagination" type="Pagination" strict="true"/>
+        <property name="sortCollection" type="Sort[]" singular="sort"/>
+        <property name="withProductLabelLocalizedAttributes" type="bool"/>
+        <property name="withProductLabelProductAbstracts" type="bool"/>
+        <property name="isActive" type="bool"/>
+    </transfer>
+
+    <transfer name="ProductLabelCollection" strict="true">
+        <property name="productLabels" type="ProductLabel[]" singular="productLabel"/>
+        <property name="pagination" type="Pagination"/>
+    </transfer>
+
+    <transfer name="Pagination">
+        <property name="offset" type="int"/>
+        <property name="limit" type="int"/>
+        <property name="nbResults" type="int"/>
+    </transfer>
+
+    <transfer name="Locale">
+    </transfer>
+
+    <transfer name="Sort">
+        <property name="field" type="string"/>
+        <property name="isAscending" type="bool"/>
     </transfer>
 
 </transfers>

--- a/src/Spryker/Zed/ProductLabel/Business/ProductLabelFacade.php
+++ b/src/Spryker/Zed/ProductLabel/Business/ProductLabelFacade.php
@@ -7,6 +7,8 @@
 
 namespace Spryker\Zed\ProductLabel\Business;
 
+use Generated\Shared\Transfer\ProductLabelCollectionTransfer;
+use Generated\Shared\Transfer\ProductLabelCriteriaTransfer;
 use Generated\Shared\Transfer\ProductLabelResponseTransfer;
 use Generated\Shared\Transfer\ProductLabelTransfer;
 use Psr\Log\LoggerInterface;
@@ -256,5 +258,20 @@ class ProductLabelFacade extends AbstractFacade implements ProductLabelFacadeInt
         $this->getFactory()
             ->createProductAbstractRelationUpdater($logger)
             ->updateProductLabelRelations($isTouchEnabled);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelCollectionTransfer
+     */
+    public function getProductLabelCollection(
+        ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+    ): ProductLabelCollectionTransfer {
+        return $this->getRepository()->getProductLabelCollection($productLabelCriteriaTransfer);
     }
 }

--- a/src/Spryker/Zed/ProductLabel/Business/ProductLabelFacadeInterface.php
+++ b/src/Spryker/Zed/ProductLabel/Business/ProductLabelFacadeInterface.php
@@ -7,6 +7,8 @@
 
 namespace Spryker\Zed\ProductLabel\Business;
 
+use Generated\Shared\Transfer\ProductLabelCollectionTransfer;
+use Generated\Shared\Transfer\ProductLabelCriteriaTransfer;
 use Generated\Shared\Transfer\ProductLabelResponseTransfer;
 use Generated\Shared\Transfer\ProductLabelTransfer;
 use Psr\Log\LoggerInterface;
@@ -205,4 +207,24 @@ interface ProductLabelFacadeInterface
      * @return void
      */
     public function updateDynamicProductLabelRelations(?LoggerInterface $logger = null, bool $isTouchEnabled = true);
+
+    /**
+     * Specification:
+     * - Fetches a collection of product labels from the Persistence.
+     * - If `ProductLabelCriteriaTransfer.productAbstractIds` is provided, filters by product abstract IDs.
+     * - If `ProductLabelCriteriaTransfer.isActive=true` is provided, returns only active product labels.
+     * - Uses `ProductLabelCriteriaTransfer.sortCollection` to sort product labels by provided fields and sort orders.
+     * - Uses `ProductLabelCriteriaTransfer.pagination.limit` and `ProductLabelCriteriaTransfer.pagination.offset` to paginate results with limit and offset.
+     * - Returns `ProductLabelCollectionTransfer` filled with found product labels.
+     * - Does not support store relations.
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelCollectionTransfer
+     */
+    public function getProductLabelCollection(
+        ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+    ): ProductLabelCollectionTransfer;
 }

--- a/src/Spryker/Zed/ProductLabel/Business/ProductLabelFacadeInterface.php
+++ b/src/Spryker/Zed/ProductLabel/Business/ProductLabelFacadeInterface.php
@@ -211,8 +211,8 @@ interface ProductLabelFacadeInterface
     /**
      * Specification:
      * - Fetches a collection of product labels from the Persistence.
-     * - If `ProductLabelCriteriaTransfer.productAbstractIds` is provided, filters by product abstract IDs.
-     * - If `ProductLabelCriteriaTransfer.isActive=true` is provided, returns only active product labels.
+     * - If `ProductLabelCriteriaTransfer.productLabelConditions.productAbstractIds` is provided, filters by product abstract IDs.
+     * - If `ProductLabelCriteriaTransfer.productLabelConditions.isActive=true` is provided, returns only active product labels.
      * - Uses `ProductLabelCriteriaTransfer.sortCollection` to sort product labels by provided fields and sort orders.
      * - Uses `ProductLabelCriteriaTransfer.pagination.limit` and `ProductLabelCriteriaTransfer.pagination.offset` to paginate results with limit and offset.
      * - Returns `ProductLabelCollectionTransfer` filled with found product labels.

--- a/src/Spryker/Zed/ProductLabel/Persistence/Mapper/LocaleMapper.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Mapper/LocaleMapper.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductLabel\Persistence\Mapper;
+
+use Generated\Shared\Transfer\LocaleTransfer;
+use Orm\Zed\Locale\Persistence\SpyLocale;
+
+class LocaleMapper
+{
+    /**
+     * @param \Orm\Zed\Locale\Persistence\SpyLocale $localeEntity
+     * @param \Generated\Shared\Transfer\LocaleTransfer $localeTransfer
+     *
+     * @return \Generated\Shared\Transfer\LocaleTransfer
+     */
+    public function mapLocaleEntityToLocaleTransfer(SpyLocale $localeEntity, LocaleTransfer $localeTransfer): LocaleTransfer
+    {
+        return $localeTransfer->fromArray($localeEntity->toArray(), true);
+    }
+}

--- a/src/Spryker/Zed/ProductLabel/Persistence/Mapper/ProductLabelLocalizedAttributesMapper.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Mapper/ProductLabelLocalizedAttributesMapper.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductLabel\Persistence\Mapper;
+
+use ArrayObject;
+use Generated\Shared\Transfer\LocaleTransfer;
+use Generated\Shared\Transfer\ProductLabelLocalizedAttributesTransfer;
+use Generated\Shared\Transfer\ProductLabelTransfer;
+use Orm\Zed\ProductLabel\Persistence\SpyProductLabel;
+use Orm\Zed\ProductLabel\Persistence\SpyProductLabelLocalizedAttributes;
+use Propel\Runtime\Collection\ObjectCollection;
+
+class ProductLabelLocalizedAttributesMapper
+{
+    /**
+     * @var \Spryker\Zed\ProductLabel\Persistence\Mapper\LocaleMapper
+     */
+    protected $localeMapper;
+
+    /**
+     * @param \Spryker\Zed\ProductLabel\Persistence\Mapper\LocaleMapper $localeMapper
+     */
+    public function __construct(LocaleMapper $localeMapper)
+    {
+        $this->localeMapper = $localeMapper;
+    }
+
+    /**
+     * @param \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\ProductLabel\Persistence\SpyProductLabelLocalizedAttributes> $productLabelLocalizedAttributesEntities
+     * @param \ArrayObject<int, \Generated\Shared\Transfer\ProductLabelLocalizedAttributesTransfer> $productLabelLocalizedAttributesTransfers
+     *
+     * @return \ArrayObject<int, \Generated\Shared\Transfer\ProductLabelLocalizedAttributesTransfer>
+     */
+    public function mapProductLabelLocalizedAttributesEntitiesToProductLabelLocalizedAttributesTransfers(
+        ObjectCollection $productLabelLocalizedAttributesEntities,
+        ArrayObject $productLabelLocalizedAttributesTransfers
+    ): ArrayObject {
+        foreach ($productLabelLocalizedAttributesEntities as $productLabelLocalizedAttributesEntity) {
+            $productLabelLocalizedAttributesTransfers->append($this->mapProductLabelLocalizedAttributesEntityToProductLabelLocalizedAttributesTransfer(
+                $productLabelLocalizedAttributesEntity,
+                new ProductLabelLocalizedAttributesTransfer()
+            ));
+        }
+
+        return $productLabelLocalizedAttributesTransfers;
+    }
+
+    /**
+     * @param \Orm\Zed\ProductLabel\Persistence\SpyProductLabelLocalizedAttributes $productLabelLocalizedAttributesEntity
+     * @param \Generated\Shared\Transfer\ProductLabelLocalizedAttributesTransfer $productLabelLocalizedAttributesTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelLocalizedAttributesTransfer
+     */
+    protected function mapProductLabelLocalizedAttributesEntityToProductLabelLocalizedAttributesTransfer(
+        SpyProductLabelLocalizedAttributes $productLabelLocalizedAttributesEntity,
+        ProductLabelLocalizedAttributesTransfer $productLabelLocalizedAttributesTransfer
+    ): ProductLabelLocalizedAttributesTransfer {
+        return $productLabelLocalizedAttributesTransfer->fromArray($productLabelLocalizedAttributesEntity->toArray(), true)
+            ->setLocale($this->localeMapper->mapLocaleEntityToLocaleTransfer($productLabelLocalizedAttributesEntity->getSpyLocale(), new LocaleTransfer()))
+            ->setProductLabel($this->mapProductLabelEntityToProductLabelTransfer($productLabelLocalizedAttributesEntity->getSpyProductLabel(), new ProductLabelTransfer()));
+    }
+
+    /**
+     * @param \Orm\Zed\ProductLabel\Persistence\SpyProductLabel $productLabelEntity
+     * @param \Generated\Shared\Transfer\ProductLabelTransfer $productLabelTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelTransfer
+     */
+    protected function mapProductLabelEntityToProductLabelTransfer(
+        SpyProductLabel $productLabelEntity,
+        ProductLabelTransfer $productLabelTransfer
+    ): ProductLabelTransfer {
+        return $productLabelTransfer->fromArray($productLabelEntity->toArray(), true);
+    }
+}

--- a/src/Spryker/Zed/ProductLabel/Persistence/Mapper/ProductLabelProductAbstractMapper.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Mapper/ProductLabelProductAbstractMapper.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductLabel\Persistence\Mapper;
+
+use Generated\Shared\Transfer\ProductLabelProductAbstractTransfer;
+use Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabelProductAbstract;
+use Propel\Runtime\Collection\ObjectCollection;
+
+class ProductLabelProductAbstractMapper
+{
+    /**
+     * @param \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\ProductLabel\Persistence\SpyProductLabelProductAbstract> $productLabelProductAbstractEntities
+     * @param array<\Generated\Shared\Transfer\ProductLabelProductAbstractTransfer> $productLabelProductAbstractTransfers
+     *
+     * @return array<\Generated\Shared\Transfer\ProductLabelProductAbstractTransfer>
+     */
+    public function mapProductLabelProductAbstractEntitiesToProductLabelProductTransfers(
+        ObjectCollection $productLabelProductAbstractEntities,
+        array $productLabelProductAbstractTransfers
+    ): array {
+        foreach ($productLabelProductAbstractEntities as $productLabelProductAbstractEntity) {
+            $productLabelProductAbstractTransfers[] = $this->mapProductLabelProductAbstractEntityToProductLabelProductTransfer(
+                $productLabelProductAbstractEntity,
+                new ProductLabelProductAbstractTransfer()
+            );
+        }
+
+        return $productLabelProductAbstractTransfers;
+    }
+
+    /**
+     * @param \Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabelProductAbstract $productLabelProductAbstractEntity
+     * @param \Generated\Shared\Transfer\ProductLabelProductAbstractTransfer $productLabelProductAbstractTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelProductAbstractTransfer
+     */
+    protected function mapProductLabelProductAbstractEntityToProductLabelProductTransfer(
+        SpyProductLabelProductAbstract $productLabelProductAbstractEntity,
+        ProductLabelProductAbstractTransfer $productLabelProductAbstractTransfer
+    ): ProductLabelProductAbstractTransfer {
+        return $productLabelProductAbstractTransfer->fromArray($productLabelProductAbstractEntity->toArray(), true);
+    }
+}

--- a/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelPersistenceFactory.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelPersistenceFactory.php
@@ -11,7 +11,10 @@ use Orm\Zed\ProductLabel\Persistence\SpyProductLabelLocalizedAttributesQuery;
 use Orm\Zed\ProductLabel\Persistence\SpyProductLabelProductAbstractQuery;
 use Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery;
 use Spryker\Zed\Kernel\Persistence\AbstractPersistenceFactory;
+use Spryker\Zed\ProductLabel\Persistence\Mapper\LocaleMapper;
+use Spryker\Zed\ProductLabel\Persistence\Mapper\ProductLabelLocalizedAttributesMapper;
 use Spryker\Zed\ProductLabel\Persistence\Mapper\ProductLabelMapper;
+use Spryker\Zed\ProductLabel\Persistence\Mapper\ProductLabelProductAbstractMapper;
 
 /**
  * @method \Spryker\Zed\ProductLabel\ProductLabelConfig getConfig()
@@ -50,6 +53,33 @@ class ProductLabelPersistenceFactory extends AbstractPersistenceFactory
      */
     public function createProductLabelMapper(): ProductLabelMapper
     {
-        return new ProductLabelMapper();
+        return new ProductLabelMapper(
+            $this->createProductLabelLocalizedAttributesMapper(),
+            $this->createProductLabelProductAbstractMapper()
+        );
+    }
+
+    /**
+     * @return \Spryker\Zed\ProductLabel\Persistence\Mapper\ProductLabelLocalizedAttributesMapper
+     */
+    public function createProductLabelLocalizedAttributesMapper(): ProductLabelLocalizedAttributesMapper
+    {
+        return new ProductLabelLocalizedAttributesMapper($this->createLocaleMapper());
+    }
+
+    /**
+     * @return \Spryker\Zed\ProductLabel\Persistence\Mapper\LocaleMapper
+     */
+    public function createLocaleMapper(): LocaleMapper
+    {
+        return new LocaleMapper();
+    }
+
+    /**
+     * @return \Spryker\Zed\ProductLabel\Persistence\Mapper\ProductLabelProductAbstractMapper
+     */
+    public function createProductLabelProductAbstractMapper(): ProductLabelProductAbstractMapper
+    {
+        return new ProductLabelProductAbstractMapper();
     }
 }

--- a/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelRepository.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelRepository.php
@@ -7,7 +7,13 @@
 
 namespace Spryker\Zed\ProductLabel\Persistence;
 
+use Generated\Shared\Transfer\PaginationTransfer;
+use Generated\Shared\Transfer\ProductLabelCollectionTransfer;
+use Generated\Shared\Transfer\ProductLabelCriteriaTransfer;
 use Generated\Shared\Transfer\ProductLabelTransfer;
+use Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Collection\ObjectCollection;
 use Spryker\Zed\Kernel\Persistence\AbstractRepository;
 
 /**
@@ -34,5 +40,196 @@ class ProductLabelRepository extends AbstractRepository implements ProductLabelR
         return $this->getFactory()
             ->createProductLabelMapper()
             ->mapProductLabelEntityToProductLabelTransfer($productLabelEntity, new ProductLabelTransfer());
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelCollectionTransfer
+     */
+    public function getProductLabelCollection(ProductLabelCriteriaTransfer $productLabelCriteriaTransfer): ProductLabelCollectionTransfer
+    {
+        $productLabelCollectionTransfer = new ProductLabelCollectionTransfer();
+        $productLabelQuery = $this->getFactory()->createProductLabelQuery();
+
+        $paginationTransfer = $productLabelCriteriaTransfer->getPagination();
+        if ($paginationTransfer) {
+            $productLabelQuery = $this->applyProductLabelPagination($productLabelQuery, $paginationTransfer);
+            $productLabelCollectionTransfer->setPagination($paginationTransfer);
+        }
+
+        $productLabelQuery = $this->applyProductLabelFilters($productLabelQuery, $productLabelCriteriaTransfer);
+        $productLabelQuery = $this->applyProductLabelSorting($productLabelQuery, $productLabelCriteriaTransfer);
+
+        $productLabelEntities = $productLabelQuery->find();
+        $productLabelEntitiesIndexedByProductLabelIds = $this->indexProductLabelEntitiesByProductLabelIds($productLabelEntities);
+
+        $this->expandProductLabelWithProductLabelLocalizedAttributes($productLabelEntitiesIndexedByProductLabelIds, $productLabelCriteriaTransfer);
+        $this->expandProductLabelWithProductLabelProductAbstracts($productLabelEntitiesIndexedByProductLabelIds, $productLabelCriteriaTransfer);
+
+        return $this->getFactory()
+            ->createProductLabelMapper()
+            ->mapProductLabelEntitiesToProductLabelCollectionTransfer(
+                $productLabelEntities,
+                $productLabelCollectionTransfer
+            );
+    }
+
+    /**
+     * @param \Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery $productLabelQuery
+     * @param \Generated\Shared\Transfer\PaginationTransfer $paginationTransfer
+     *
+     * @return \Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery
+     */
+    protected function applyProductLabelPagination(
+        SpyProductLabelQuery $productLabelQuery,
+        PaginationTransfer $paginationTransfer
+    ): SpyProductLabelQuery {
+        $paginationTransfer->setNbResults($productLabelQuery->count());
+
+        if ($paginationTransfer->getLimit() !== null && $paginationTransfer->getOffset() !== null) {
+            return $productLabelQuery
+                ->limit($paginationTransfer->getLimit())
+                ->offset($paginationTransfer->getOffset());
+        }
+
+        return $productLabelQuery;
+    }
+
+    /**
+     * @param \Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery $productLabelQuery
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return \Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery
+     */
+    protected function applyProductLabelFilters(
+        SpyProductLabelQuery $productLabelQuery,
+        ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+    ): SpyProductLabelQuery {
+        if ($productLabelCriteriaTransfer->getProductAbstractIds()) {
+            $productLabelQuery->useSpyProductLabelProductAbstractQuery()
+                ->filterByFkProductAbstract_In($productLabelCriteriaTransfer->getProductAbstractIds())
+                ->endUse();
+        }
+
+        if ($productLabelCriteriaTransfer->getIsActive()) {
+            $productLabelQuery->filterByIsActive(true)
+                ->filterByValidFrom('now', Criteria::LESS_EQUAL)
+                ->_or()
+                ->filterByValidFrom(null, Criteria::ISNULL)
+                ->filterByValidTo('now', Criteria::GREATER_EQUAL)
+                ->_or()
+                ->filterByValidTo(null, Criteria::ISNULL);
+        }
+
+        return $productLabelQuery;
+    }
+
+    /**
+     * @param \Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery $productLabelQuery
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return \Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery
+     */
+    protected function applyProductLabelSorting(
+        SpyProductLabelQuery $productLabelQuery,
+        ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+    ): SpyProductLabelQuery {
+        $sortCollection = $productLabelCriteriaTransfer->getSortCollection();
+        foreach ($sortCollection as $sortTransfer) {
+            $productLabelQuery->orderBy(
+                $sortTransfer->getFieldOrFail(),
+                $sortTransfer->getIsAscending() ? Criteria::ASC : Criteria::DESC
+            );
+        }
+
+        return $productLabelQuery;
+    }
+
+    /**
+     * @param \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\ProductLabel\Persistence\SpyProductLabel> $productLabelEntities
+     *
+     * @return array<int, \Orm\Zed\ProductLabel\Persistence\SpyProductLabel>
+     */
+    protected function indexProductLabelEntitiesByProductLabelIds(ObjectCollection $productLabelEntities): array
+    {
+        $productLabelEntitiesIndexedByProductLabelIds = [];
+        foreach ($productLabelEntities as $productLabelEntity) {
+            $productLabelEntitiesIndexedByProductLabelIds[$productLabelEntity->getIdProductLabel()] = $productLabelEntity;
+        }
+
+        return $productLabelEntitiesIndexedByProductLabelIds;
+    }
+
+    /**
+     * @param array<int, \Orm\Zed\ProductLabel\Persistence\SpyProductLabel> $productLabelEntitiesIndexedByProductLabelIds
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return array<int, \Orm\Zed\ProductLabel\Persistence\SpyProductLabel>
+     */
+    protected function expandProductLabelWithProductLabelLocalizedAttributes(
+        array $productLabelEntitiesIndexedByProductLabelIds,
+        ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+    ): array {
+        foreach ($productLabelEntitiesIndexedByProductLabelIds as $productLabelEntity) {
+            $productLabelEntity->initSpyProductLabelLocalizedAttributess(false);
+        }
+
+        if (!$productLabelCriteriaTransfer->getWithProductLabelLocalizedAttributes()) {
+            return $productLabelEntitiesIndexedByProductLabelIds;
+        }
+
+        $productLabelLocalizedAttributeEntities = $this->getFactory()
+            ->createLocalizedAttributesQuery()
+            ->leftJoinWithSpyLocale()
+            ->leftJoinWithSpyProductLabel()
+            ->filterByFkProductLabel_In(array_keys($productLabelEntitiesIndexedByProductLabelIds))
+            ->find();
+
+        foreach ($productLabelLocalizedAttributeEntities as $productLabelLocalizedAttributeEntity) {
+            $productLabelId = $productLabelLocalizedAttributeEntity->getFkProductLabel();
+            if (!isset($productLabelEntitiesIndexedByProductLabelIds[$productLabelId])) {
+                continue;
+            }
+
+            $productLabelEntitiesIndexedByProductLabelIds[$productLabelId]->addSpyProductLabelLocalizedAttributes($productLabelLocalizedAttributeEntity);
+        }
+
+        return $productLabelEntitiesIndexedByProductLabelIds;
+    }
+
+    /**
+     * @param array<int, \Orm\Zed\ProductLabel\Persistence\SpyProductLabel> $productLabelEntitiesIndexedByProductLabelIds
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return array<int, \Orm\Zed\ProductLabel\Persistence\SpyProductLabel>
+     */
+    protected function expandProductLabelWithProductLabelProductAbstracts(
+        array $productLabelEntitiesIndexedByProductLabelIds,
+        ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+    ): array {
+        foreach ($productLabelEntitiesIndexedByProductLabelIds as $productLabelEntity) {
+            $productLabelEntity->initSpyProductLabelProductAbstracts(false);
+        }
+
+        if (!$productLabelCriteriaTransfer->getWithProductLabelProductAbstracts()) {
+            return $productLabelEntitiesIndexedByProductLabelIds;
+        }
+
+        $productLabelProductAbstractEntities = $this->getFactory()
+            ->createProductRelationQuery()
+            ->filterByFkProductLabel_In(array_keys($productLabelEntitiesIndexedByProductLabelIds))
+            ->find();
+
+        foreach ($productLabelProductAbstractEntities as $productLabelProductAbstractEntity) {
+            $productLabelId = $productLabelProductAbstractEntity->getFkProductLabel();
+            if (!isset($productLabelEntitiesIndexedByProductLabelIds[$productLabelId])) {
+                continue;
+            }
+
+            $productLabelEntitiesIndexedByProductLabelIds[$productLabelId]->addSpyProductLabelProductAbstract($productLabelProductAbstractEntity);
+        }
+
+        return $productLabelEntitiesIndexedByProductLabelIds;
     }
 }

--- a/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelRepository.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelRepository.php
@@ -58,7 +58,7 @@ class ProductLabelRepository extends AbstractRepository implements ProductLabelR
             $productLabelCollectionTransfer->setPagination($paginationTransfer);
         }
 
-        $productLabelQuery = $this->applyProductLabelFilters($productLabelQuery, $productLabelCriteriaTransfer);
+        $productLabelQuery = $this->applyProductLabelConditions($productLabelQuery, $productLabelCriteriaTransfer);
         $productLabelQuery = $this->applyProductLabelSorting($productLabelQuery, $productLabelCriteriaTransfer);
 
         $productLabelEntities = $productLabelQuery->find();
@@ -102,17 +102,23 @@ class ProductLabelRepository extends AbstractRepository implements ProductLabelR
      *
      * @return \Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery
      */
-    protected function applyProductLabelFilters(
+    protected function applyProductLabelConditions(
         SpyProductLabelQuery $productLabelQuery,
         ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
     ): SpyProductLabelQuery {
-        if ($productLabelCriteriaTransfer->getProductAbstractIds()) {
+        $productLabelConditions = $productLabelCriteriaTransfer->getProductLabelConditions();
+        if (!$productLabelConditions) {
+            return $productLabelQuery;
+        }
+
+        if ($productLabelConditions->getProductAbstractIds()) {
             $productLabelQuery->useSpyProductLabelProductAbstractQuery()
-                ->filterByFkProductAbstract_In($productLabelCriteriaTransfer->getProductAbstractIds())
+                ->filterByFkProductAbstract_In(
+                    $productLabelConditions->getProductAbstractIds())
                 ->endUse();
         }
 
-        if ($productLabelCriteriaTransfer->getIsActive()) {
+        if ($productLabelConditions->getIsActive()) {
             $productLabelQuery->filterByIsActive(true)
                 ->filterByValidFrom('now', Criteria::LESS_EQUAL)
                 ->_or()

--- a/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelRepositoryInterface.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelRepositoryInterface.php
@@ -7,6 +7,8 @@
 
 namespace Spryker\Zed\ProductLabel\Persistence;
 
+use Generated\Shared\Transfer\ProductLabelCollectionTransfer;
+use Generated\Shared\Transfer\ProductLabelCriteriaTransfer;
 use Generated\Shared\Transfer\ProductLabelTransfer;
 
 interface ProductLabelRepositoryInterface
@@ -17,4 +19,11 @@ interface ProductLabelRepositoryInterface
      * @return \Generated\Shared\Transfer\ProductLabelTransfer|null
      */
     public function findProductLabelById(int $idProductLabel): ?ProductLabelTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelCollectionTransfer
+     */
+    public function getProductLabelCollection(ProductLabelCriteriaTransfer $productLabelCriteriaTransfer): ProductLabelCollectionTransfer;
 }


### PR DESCRIPTION
Branch: backport/2.9.0
Ticket: https://spryker.atlassian.net/browse/SUPESC-667
Version: 2.9.0

#### Release Table

   Module                | Release Type         | Constraint Updates         
   :--------------------- | :------------------------ | :---------------------  |
   ProductLabel  | minor                 |                        |

-----------------------------------------

#### Module ProductLabel

##### Change log

Improvements

- Introduced `ProductLabelFacade::getProductLabelCollection()` to fetch product labels from Persistence.
- Introduced `ProductLabelProductAbstract` transfer. 
- Introduced `ProductLabelCriteria` transfer. 
- Introduced `ProductLabelCollection` transfer. 
- Introduced `ProductLabelConditions` transfer. 
- Introduced `Pagination` transfer.  
- Introduced `Locale` transfer. 
- Introduced `Sort` transfer.
- Introduced `ProductLabel.productLabelProductAbstracts` transfer field. 
- Added `Transfer` module to dependencies.
