### PR TITLE
SUPESC-667 Backport for get product label collection.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,14 @@
   "description": "ProductLabel module",
   "license": "proprietary",
   "require": {
-    "spryker/kernel": "^3.0.0",
+    "spryker/kernel": "^3.17.0",
     "spryker/key-builder": "^1.0.0",
     "spryker/locale": "^3.1.0",
     "spryker/propel-orm": "^1.1.0",
     "spryker/storage": "^3.0.0",
     "spryker/symfony": "^3.0.0",
     "spryker/touch": "^3.1.0",
+    "spryker/transfer": "^3.27.0",
     "spryker/twig": "^3.0.0"
   },
   "require-dev": {

--- a/dependency.json
+++ b/dependency.json
@@ -1,0 +1,5 @@
+{
+    "include": {
+        "spryker/transfer": "Provides transfer objects definition with strict types and `::get*OrFail()` functionality."
+    }
+}

--- a/src/Spryker/Shared/ProductLabel/Transfer/product_label.transfer.xml
+++ b/src/Spryker/Shared/ProductLabel/Transfer/product_label.transfer.xml
@@ -20,6 +20,7 @@
             singular="localizedAttributes"
             type="ProductLabelLocalizedAttributes[]"
         />
+        <property name="productLabelProductAbstracts" type="ProductLabelProductAbstract[]" singular="productLabelProductAbstract"/>
     </transfer>
 
     <transfer name="ProductLabelLocalizedAttributes">
@@ -34,6 +35,41 @@
         <property name="isExclusive" type="bool"/>
         <property name="position" type="int"/>
         <property name="frontEndReference" type="string"/>
+    </transfer>
+
+    <transfer name="ProductLabelProductAbstract">
+        <property name="idProductLabelProductAbstract" type="int"/>
+        <property name="fkProductAbstract" type="int"/>
+        <property name="fkProductLabel" type="int"/>
+    </transfer>
+
+    <transfer name="ProductLabelCriteria">
+        <property name="productAbstractIds" type="int[]" singular="productAbstractId"/>
+        <property name="productLabelIds" type="int[]" singular="productLabelId"/>
+        <property name="pagination" type="Pagination" strict="true"/>
+        <property name="sortCollection" type="Sort[]" singular="sort"/>
+        <property name="withProductLabelLocalizedAttributes" type="bool"/>
+        <property name="withProductLabelProductAbstracts" type="bool"/>
+        <property name="isActive" type="bool"/>
+    </transfer>
+
+    <transfer name="ProductLabelCollection" strict="true">
+        <property name="productLabels" type="ProductLabel[]" singular="productLabel"/>
+        <property name="pagination" type="Pagination"/>
+    </transfer>
+
+    <transfer name="Pagination">
+        <property name="offset" type="int"/>
+        <property name="limit" type="int"/>
+        <property name="nbResults" type="int"/>
+    </transfer>
+
+    <transfer name="Locale">
+    </transfer>
+
+    <transfer name="Sort">
+        <property name="field" type="string"/>
+        <property name="isAscending" type="bool"/>
     </transfer>
 
 </transfers>

--- a/src/Spryker/Shared/ProductLabel/Transfer/product_label.transfer.xml
+++ b/src/Spryker/Shared/ProductLabel/Transfer/product_label.transfer.xml
@@ -44,13 +44,12 @@
     </transfer>
 
     <transfer name="ProductLabelCriteria">
-        <property name="productAbstractIds" type="int[]" singular="productAbstractId"/>
+        <property name="productLabelConditions" type="ProductLabelConditions" strict="true"/>
         <property name="productLabelIds" type="int[]" singular="productLabelId"/>
         <property name="pagination" type="Pagination" strict="true"/>
-        <property name="sortCollection" type="Sort[]" singular="sort"/>
+        <property name="sortCollection" type="Sort[]" singular="sort" strict="true"/>
         <property name="withProductLabelLocalizedAttributes" type="bool"/>
         <property name="withProductLabelProductAbstracts" type="bool"/>
-        <property name="isActive" type="bool"/>
     </transfer>
 
     <transfer name="ProductLabelCollection" strict="true">
@@ -70,6 +69,11 @@
     <transfer name="Sort">
         <property name="field" type="string"/>
         <property name="isAscending" type="bool"/>
+    </transfer>
+
+    <transfer name="ProductLabelConditions" strict="true">
+        <property name="productAbstractIds" type="int[]" singular="productAbstractId"/>
+        <property name="isActive" type="bool"/>
     </transfer>
 
 </transfers>

--- a/src/Spryker/Zed/ProductLabel/Business/ProductLabelFacade.php
+++ b/src/Spryker/Zed/ProductLabel/Business/ProductLabelFacade.php
@@ -7,6 +7,8 @@
 
 namespace Spryker\Zed\ProductLabel\Business;
 
+use Generated\Shared\Transfer\ProductLabelCollectionTransfer;
+use Generated\Shared\Transfer\ProductLabelCriteriaTransfer;
 use Generated\Shared\Transfer\ProductLabelTransfer;
 use Spryker\Zed\Kernel\Business\AbstractFacade;
 
@@ -14,6 +16,7 @@ use Spryker\Zed\Kernel\Business\AbstractFacade;
  * @api
  *
  * @method \Spryker\Zed\ProductLabel\Business\ProductLabelBusinessFactory getFactory()
+ * @method \Spryker\Zed\ProductLabel\Persistence\ProductLabelRepositoryInterface getRepository()
  */
 class ProductLabelFacade extends AbstractFacade implements ProductLabelFacadeInterface
 {
@@ -169,6 +172,21 @@ class ProductLabelFacade extends AbstractFacade implements ProductLabelFacadeInt
             ->getFactory()
             ->createLabelValidityUpdater()
             ->checkAndTouchAllLabels();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelCollectionTransfer
+     */
+    public function getProductLabelCollection(
+        ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+    ): ProductLabelCollectionTransfer {
+        return $this->getRepository()->getProductLabelCollection($productLabelCriteriaTransfer);
     }
 
 }

--- a/src/Spryker/Zed/ProductLabel/Business/ProductLabelFacadeInterface.php
+++ b/src/Spryker/Zed/ProductLabel/Business/ProductLabelFacadeInterface.php
@@ -138,8 +138,8 @@ interface ProductLabelFacadeInterface
     /**
      * Specification:
      * - Fetches a collection of product labels from the Persistence.
-     * - If `ProductLabelCriteriaTransfer.productAbstractIds` is provided, filters by product abstract IDs.
-     * - If `ProductLabelCriteriaTransfer.isActive=true` is provided, returns only active product labels.
+     * - If `ProductLabelCriteriaTransfer.productLabelConditions.productAbstractIds` is provided, filters by product abstract IDs.
+     * - If `ProductLabelCriteriaTransfer.productLabelConditions.isActive=true` is provided, returns only active product labels.
      * - Uses `ProductLabelCriteriaTransfer.sortCollection` to sort product labels by provided fields and sort orders.
      * - Uses `ProductLabelCriteriaTransfer.pagination.limit` and `ProductLabelCriteriaTransfer.pagination.offset` to paginate results with limit and offset.
      * - Returns `ProductLabelCollectionTransfer` filled with found product labels.

--- a/src/Spryker/Zed/ProductLabel/Business/ProductLabelFacadeInterface.php
+++ b/src/Spryker/Zed/ProductLabel/Business/ProductLabelFacadeInterface.php
@@ -7,6 +7,8 @@
 
 namespace Spryker\Zed\ProductLabel\Business;
 
+use Generated\Shared\Transfer\ProductLabelCollectionTransfer;
+use Generated\Shared\Transfer\ProductLabelCriteriaTransfer;
 use Generated\Shared\Transfer\ProductLabelTransfer;
 
 interface ProductLabelFacadeInterface
@@ -131,5 +133,26 @@ interface ProductLabelFacadeInterface
      * @return void
      */
     public function checkLabelValidityDateRangeAndTouch();
+
+
+    /**
+     * Specification:
+     * - Fetches a collection of product labels from the Persistence.
+     * - If `ProductLabelCriteriaTransfer.productAbstractIds` is provided, filters by product abstract IDs.
+     * - If `ProductLabelCriteriaTransfer.isActive=true` is provided, returns only active product labels.
+     * - Uses `ProductLabelCriteriaTransfer.sortCollection` to sort product labels by provided fields and sort orders.
+     * - Uses `ProductLabelCriteriaTransfer.pagination.limit` and `ProductLabelCriteriaTransfer.pagination.offset` to paginate results with limit and offset.
+     * - Returns `ProductLabelCollectionTransfer` filled with found product labels.
+     * - Does not support store relations.
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelCollectionTransfer
+     */
+    public function getProductLabelCollection(
+        ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+    ): ProductLabelCollectionTransfer;
 
 }

--- a/src/Spryker/Zed/ProductLabel/Persistence/Mapper/LocaleMapper.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Mapper/LocaleMapper.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductLabel\Persistence\Mapper;
+
+use Generated\Shared\Transfer\LocaleTransfer;
+use Orm\Zed\Locale\Persistence\SpyLocale;
+
+class LocaleMapper
+{
+    /**
+     * @param \Orm\Zed\Locale\Persistence\SpyLocale $localeEntity
+     * @param \Generated\Shared\Transfer\LocaleTransfer $localeTransfer
+     *
+     * @return \Generated\Shared\Transfer\LocaleTransfer
+     */
+    public function mapLocaleEntityToLocaleTransfer(SpyLocale $localeEntity, LocaleTransfer $localeTransfer): LocaleTransfer
+    {
+        return $localeTransfer->fromArray($localeEntity->toArray(), true);
+    }
+}

--- a/src/Spryker/Zed/ProductLabel/Persistence/Mapper/ProductLabelLocalizedAttributesMapper.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Mapper/ProductLabelLocalizedAttributesMapper.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductLabel\Persistence\Mapper;
+
+use ArrayObject;
+use Generated\Shared\Transfer\LocaleTransfer;
+use Generated\Shared\Transfer\ProductLabelLocalizedAttributesTransfer;
+use Generated\Shared\Transfer\ProductLabelTransfer;
+use Orm\Zed\ProductLabel\Persistence\SpyProductLabel;
+use Orm\Zed\ProductLabel\Persistence\SpyProductLabelLocalizedAttributes;
+use Propel\Runtime\Collection\ObjectCollection;
+
+class ProductLabelLocalizedAttributesMapper
+{
+    /**
+     * @var \Spryker\Zed\ProductLabel\Persistence\Mapper\LocaleMapper
+     */
+    protected $localeMapper;
+
+    /**
+     * @param \Spryker\Zed\ProductLabel\Persistence\Mapper\LocaleMapper $localeMapper
+     */
+    public function __construct(LocaleMapper $localeMapper)
+    {
+        $this->localeMapper = $localeMapper;
+    }
+
+    /**
+     * @param \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\ProductLabel\Persistence\SpyProductLabelLocalizedAttributes> $productLabelLocalizedAttributesEntities
+     * @param \ArrayObject<int, \Generated\Shared\Transfer\ProductLabelLocalizedAttributesTransfer> $productLabelLocalizedAttributesTransfers
+     *
+     * @return \ArrayObject<int, \Generated\Shared\Transfer\ProductLabelLocalizedAttributesTransfer>
+     */
+    public function mapProductLabelLocalizedAttributesEntitiesToProductLabelLocalizedAttributesTransfers(
+        ObjectCollection $productLabelLocalizedAttributesEntities,
+        ArrayObject $productLabelLocalizedAttributesTransfers
+    ): ArrayObject {
+        foreach ($productLabelLocalizedAttributesEntities as $productLabelLocalizedAttributesEntity) {
+            $productLabelLocalizedAttributesTransfers->append($this->mapProductLabelLocalizedAttributesEntityToProductLabelLocalizedAttributesTransfer(
+                $productLabelLocalizedAttributesEntity,
+                new ProductLabelLocalizedAttributesTransfer(),
+            ));
+        }
+
+        return $productLabelLocalizedAttributesTransfers;
+    }
+
+    /**
+     * @param \Orm\Zed\ProductLabel\Persistence\SpyProductLabelLocalizedAttributes $productLabelLocalizedAttributesEntity
+     * @param \Generated\Shared\Transfer\ProductLabelLocalizedAttributesTransfer $productLabelLocalizedAttributesTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelLocalizedAttributesTransfer
+     */
+    protected function mapProductLabelLocalizedAttributesEntityToProductLabelLocalizedAttributesTransfer(
+        SpyProductLabelLocalizedAttributes $productLabelLocalizedAttributesEntity,
+        ProductLabelLocalizedAttributesTransfer $productLabelLocalizedAttributesTransfer
+    ): ProductLabelLocalizedAttributesTransfer {
+        return $productLabelLocalizedAttributesTransfer->fromArray($productLabelLocalizedAttributesEntity->toArray(), true)
+            ->setLocale($this->localeMapper->mapLocaleEntityToLocaleTransfer($productLabelLocalizedAttributesEntity->getSpyLocale(), new LocaleTransfer()))
+            ->setProductLabel($this->mapProductLabelEntityToProductLabelTransfer($productLabelLocalizedAttributesEntity->getSpyProductLabel(), new ProductLabelTransfer()));
+    }
+
+    /**
+     * @param \Orm\Zed\ProductLabel\Persistence\SpyProductLabel $productLabelEntity
+     * @param \Generated\Shared\Transfer\ProductLabelTransfer $productLabelTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelTransfer
+     */
+    protected function mapProductLabelEntityToProductLabelTransfer(
+        SpyProductLabel $productLabelEntity,
+        ProductLabelTransfer $productLabelTransfer
+    ): ProductLabelTransfer {
+        return $productLabelTransfer->fromArray($productLabelEntity->toArray(), true);
+    }
+}

--- a/src/Spryker/Zed/ProductLabel/Persistence/Mapper/ProductLabelLocalizedAttributesMapper.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Mapper/ProductLabelLocalizedAttributesMapper.php
@@ -43,7 +43,7 @@ class ProductLabelLocalizedAttributesMapper
         foreach ($productLabelLocalizedAttributesEntities as $productLabelLocalizedAttributesEntity) {
             $productLabelLocalizedAttributesTransfers->append($this->mapProductLabelLocalizedAttributesEntityToProductLabelLocalizedAttributesTransfer(
                 $productLabelLocalizedAttributesEntity,
-                new ProductLabelLocalizedAttributesTransfer(),
+                new ProductLabelLocalizedAttributesTransfer()
             ));
         }
 

--- a/src/Spryker/Zed/ProductLabel/Persistence/Mapper/ProductLabelMapper.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Mapper/ProductLabelMapper.php
@@ -9,11 +9,8 @@ namespace Spryker\Zed\ProductLabel\Persistence\Mapper;
 
 use ArrayObject;
 use Generated\Shared\Transfer\ProductLabelCollectionTransfer;
-use Generated\Shared\Transfer\ProductLabelLocalizedAttributesTransfer;
 use Generated\Shared\Transfer\ProductLabelTransfer;
-use Generated\Shared\Transfer\StoreRelationTransfer;
 use Orm\Zed\ProductLabel\Persistence\SpyProductLabel;
-use Orm\Zed\ProductLabel\Persistence\SpyProductLabelLocalizedAttributes;
 use Propel\Runtime\Collection\ObjectCollection;
 
 class ProductLabelMapper

--- a/src/Spryker/Zed/ProductLabel/Persistence/Mapper/ProductLabelMapper.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Mapper/ProductLabelMapper.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductLabel\Persistence\Mapper;
+
+use ArrayObject;
+use Generated\Shared\Transfer\ProductLabelCollectionTransfer;
+use Generated\Shared\Transfer\ProductLabelLocalizedAttributesTransfer;
+use Generated\Shared\Transfer\ProductLabelTransfer;
+use Generated\Shared\Transfer\StoreRelationTransfer;
+use Orm\Zed\ProductLabel\Persistence\SpyProductLabel;
+use Orm\Zed\ProductLabel\Persistence\SpyProductLabelLocalizedAttributes;
+use Propel\Runtime\Collection\ObjectCollection;
+
+class ProductLabelMapper
+{
+    /**
+     * @var string
+     */
+    protected const VALIDITY_DATE_FORMAT = 'Y-m-d';
+
+    /**
+     * @var \Spryker\Zed\ProductLabel\Persistence\Mapper\ProductLabelLocalizedAttributesMapper
+     */
+    protected $productLabelLocalizedAttributesMapper;
+
+    /**
+     * @var \Spryker\Zed\ProductLabel\Persistence\Mapper\ProductLabelProductAbstractMapper
+     */
+    protected $productLabelProductAbstractMapper;
+
+    /**
+     * @param \Spryker\Zed\ProductLabel\Persistence\Mapper\ProductLabelLocalizedAttributesMapper $productLabelLocalizedAttributesMapper
+     * @param \Spryker\Zed\ProductLabel\Persistence\Mapper\ProductLabelProductAbstractMapper $productLabelProductAbstractMapper
+     */
+    public function __construct(
+        ProductLabelLocalizedAttributesMapper $productLabelLocalizedAttributesMapper,
+        ProductLabelProductAbstractMapper $productLabelProductAbstractMapper
+    ) {
+        $this->productLabelLocalizedAttributesMapper = $productLabelLocalizedAttributesMapper;
+        $this->productLabelProductAbstractMapper = $productLabelProductAbstractMapper;
+    }
+
+    /**
+     * @param \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\ProductLabel\Persistence\SpyProductLabel> $productLabelEntities
+     * @param array<\Generated\Shared\Transfer\ProductLabelTransfer> $productLabelTransfers
+     *
+     * @return array<\Generated\Shared\Transfer\ProductLabelTransfer>
+     */
+    public function mapProductLabelEntitiesToProductLabelTransfers(
+        ObjectCollection $productLabelEntities,
+        array $productLabelTransfers
+    ): array {
+        foreach ($productLabelEntities as $productLabelEntity) {
+            $productLabelTransfers[] = $this->mapProductLabelEntityToProductLabelTransfer(
+                $productLabelEntity,
+                new ProductLabelTransfer()
+            );
+        }
+
+        return $productLabelTransfers;
+    }
+
+    /**
+     * @param \Orm\Zed\ProductLabel\Persistence\SpyProductLabel $productLabelEntity
+     * @param \Generated\Shared\Transfer\ProductLabelTransfer $productLabelTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelTransfer
+     */
+    public function mapProductLabelEntityToProductLabelTransfer(
+        SpyProductLabel $productLabelEntity,
+        ProductLabelTransfer $productLabelTransfer
+    ): ProductLabelTransfer {
+        $productLabelTransfer->fromArray($productLabelEntity->toArray(), true);
+
+        $productLabelTransfer->setValidFrom(
+            $productLabelEntity->getValidFrom(static::VALIDITY_DATE_FORMAT)
+        );
+        $productLabelTransfer->setValidTo(
+            $productLabelEntity->getValidTo(static::VALIDITY_DATE_FORMAT)
+        );
+
+        $productLabelEntity->initSpyProductLabelLocalizedAttributess(false);
+
+        $productLabelLocalizedAttributesTransfers = $this->productLabelLocalizedAttributesMapper
+            ->mapProductLabelLocalizedAttributesEntitiesToProductLabelLocalizedAttributesTransfers(
+                $productLabelEntity->getSpyProductLabelLocalizedAttributess(),
+                $productLabelTransfer->getLocalizedAttributesCollection()
+            );
+        $productLabelTransfer->setLocalizedAttributesCollection(
+            new ArrayObject($productLabelLocalizedAttributesTransfers)
+        );
+
+        $productLabelProductAbstractTransfers = $this->productLabelProductAbstractMapper
+            ->mapProductLabelProductAbstractEntitiesToProductLabelProductTransfers(
+                $productLabelEntity->getSpyProductLabelProductAbstracts(),
+                []
+            );
+        $productLabelTransfer->setProductLabelProductAbstracts(
+            new ArrayObject($productLabelProductAbstractTransfers)
+        );
+
+        return $productLabelTransfer;
+    }
+
+    /**
+     * @param \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\ProductLabel\Persistence\SpyProductLabel> $productLabelEntities
+     * @param \Generated\Shared\Transfer\ProductLabelCollectionTransfer $productLabelCollectionTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelCollectionTransfer
+     */
+    public function mapProductLabelEntitiesToProductLabelCollectionTransfer(
+        ObjectCollection $productLabelEntities,
+        ProductLabelCollectionTransfer $productLabelCollectionTransfer
+    ): ProductLabelCollectionTransfer {
+        foreach ($productLabelEntities as $productLabelEntity) {
+            $productLabelCollectionTransfer->addProductLabel(
+                $this->mapProductLabelEntityToProductLabelTransfer($productLabelEntity, new ProductLabelTransfer())
+            );
+        }
+
+        return $productLabelCollectionTransfer;
+    }
+}

--- a/src/Spryker/Zed/ProductLabel/Persistence/Mapper/ProductLabelProductAbstractMapper.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Mapper/ProductLabelProductAbstractMapper.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductLabel\Persistence\Mapper;
+
+use Generated\Shared\Transfer\ProductLabelProductAbstractTransfer;
+use Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabelProductAbstract;
+use Propel\Runtime\Collection\ObjectCollection;
+
+class ProductLabelProductAbstractMapper
+{
+    /**
+     * @param \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\ProductLabel\Persistence\SpyProductLabelProductAbstract> $productLabelProductAbstractEntities
+     * @param array<\Generated\Shared\Transfer\ProductLabelProductAbstractTransfer> $productLabelProductAbstractTransfers
+     *
+     * @return array<\Generated\Shared\Transfer\ProductLabelProductAbstractTransfer>
+     */
+    public function mapProductLabelProductAbstractEntitiesToProductLabelProductTransfers(
+        ObjectCollection $productLabelProductAbstractEntities,
+        array $productLabelProductAbstractTransfers
+    ): array {
+        foreach ($productLabelProductAbstractEntities as $productLabelProductAbstractEntity) {
+            $productLabelProductAbstractTransfers[] = $this->mapProductLabelProductAbstractEntityToProductLabelProductTransfer(
+                $productLabelProductAbstractEntity,
+                new ProductLabelProductAbstractTransfer()
+            );
+        }
+
+        return $productLabelProductAbstractTransfers;
+    }
+
+    /**
+     * @param \Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabelProductAbstract $productLabelProductAbstractEntity
+     * @param \Generated\Shared\Transfer\ProductLabelProductAbstractTransfer $productLabelProductAbstractTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelProductAbstractTransfer
+     */
+    protected function mapProductLabelProductAbstractEntityToProductLabelProductTransfer(
+        SpyProductLabelProductAbstract $productLabelProductAbstractEntity,
+        ProductLabelProductAbstractTransfer $productLabelProductAbstractTransfer
+    ): ProductLabelProductAbstractTransfer {
+        return $productLabelProductAbstractTransfer->fromArray($productLabelProductAbstractEntity->toArray(), true);
+    }
+}

--- a/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelPersistenceFactory.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelPersistenceFactory.php
@@ -11,6 +11,10 @@ use Orm\Zed\ProductLabel\Persistence\SpyProductLabelLocalizedAttributesQuery;
 use Orm\Zed\ProductLabel\Persistence\SpyProductLabelProductAbstractQuery;
 use Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery;
 use Spryker\Zed\Kernel\Persistence\AbstractPersistenceFactory;
+use Spryker\Zed\ProductLabel\Persistence\Mapper\LocaleMapper;
+use Spryker\Zed\ProductLabel\Persistence\Mapper\ProductLabelLocalizedAttributesMapper;
+use Spryker\Zed\ProductLabel\Persistence\Mapper\ProductLabelMapper;
+use Spryker\Zed\ProductLabel\Persistence\Mapper\ProductLabelProductAbstractMapper;
 
 /**
  * @method \Spryker\Zed\ProductLabel\ProductLabelConfig getConfig()
@@ -41,6 +45,41 @@ class ProductLabelPersistenceFactory extends AbstractPersistenceFactory
     public function createProductRelationQuery()
     {
         return SpyProductLabelProductAbstractQuery::create();
+    }
+
+    /**
+     * @return \Spryker\Zed\ProductLabel\Persistence\Mapper\ProductLabelMapper
+     */
+    public function createProductLabelMapper(): ProductLabelMapper
+    {
+        return new ProductLabelMapper(
+            $this->createProductLabelLocalizedAttributesMapper(),
+            $this->createProductLabelProductAbstractMapper()
+        );
+    }
+
+    /**
+     * @return \Spryker\Zed\ProductLabel\Persistence\Mapper\ProductLabelLocalizedAttributesMapper
+     */
+    public function createProductLabelLocalizedAttributesMapper(): ProductLabelLocalizedAttributesMapper
+    {
+        return new ProductLabelLocalizedAttributesMapper($this->createLocaleMapper());
+    }
+
+    /**
+     * @return \Spryker\Zed\ProductLabel\Persistence\Mapper\LocaleMapper
+     */
+    public function createLocaleMapper(): LocaleMapper
+    {
+        return new LocaleMapper();
+    }
+
+    /**
+     * @return \Spryker\Zed\ProductLabel\Persistence\Mapper\ProductLabelProductAbstractMapper
+     */
+    public function createProductLabelProductAbstractMapper(): ProductLabelProductAbstractMapper
+    {
+        return new ProductLabelProductAbstractMapper();
     }
 
 }

--- a/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelRepository.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelRepository.php
@@ -37,7 +37,7 @@ class ProductLabelRepository extends AbstractRepository implements ProductLabelR
             $productLabelCollectionTransfer->setPagination($paginationTransfer);
         }
 
-        $productLabelQuery = $this->applyProductLabelFilters($productLabelQuery, $productLabelCriteriaTransfer);
+        $productLabelQuery = $this->applyProductLabelConditions($productLabelQuery, $productLabelCriteriaTransfer);
         $productLabelQuery = $this->applyProductLabelSorting($productLabelQuery, $productLabelCriteriaTransfer);
 
         $productLabelEntities = $productLabelQuery->find();
@@ -75,24 +75,29 @@ class ProductLabelRepository extends AbstractRepository implements ProductLabelR
         return $productLabelQuery;
     }
 
-
     /**
      * @param \Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery $productLabelQuery
      * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
      *
      * @return \Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery
      */
-    protected function applyProductLabelFilters(
+    protected function applyProductLabelConditions(
         SpyProductLabelQuery $productLabelQuery,
         ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
     ): SpyProductLabelQuery {
-        if ($productLabelCriteriaTransfer->getProductAbstractIds()) {
+        $productLabelConditions = $productLabelCriteriaTransfer->getProductLabelConditions();
+        if (!$productLabelConditions) {
+            return $productLabelQuery;
+        }
+
+        if ($productLabelConditions->getProductAbstractIds()) {
             $productLabelQuery->useSpyProductLabelProductAbstractQuery()
-                ->filterByFkProductAbstract_In($productLabelCriteriaTransfer->getProductAbstractIds())
+                ->filterByFkProductAbstract_In(
+                    $productLabelConditions->getProductAbstractIds())
                 ->endUse();
         }
 
-        if ($productLabelCriteriaTransfer->getIsActive()) {
+        if ($productLabelConditions->getIsActive()) {
             $productLabelQuery->filterByIsActive(true)
                 ->filterByValidFrom('now', Criteria::LESS_EQUAL)
                 ->_or()

--- a/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelRepository.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelRepository.php
@@ -1,0 +1,215 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductLabel\Persistence;
+
+use Generated\Shared\Transfer\PaginationTransfer;
+use Generated\Shared\Transfer\ProductLabelCollectionTransfer;
+use Generated\Shared\Transfer\ProductLabelCriteriaTransfer;
+use Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Collection\ObjectCollection;
+use Spryker\Zed\Kernel\Persistence\AbstractRepository;
+
+/**
+ * @method \Spryker\Zed\ProductLabel\Persistence\ProductLabelPersistenceFactory getFactory()
+ */
+class ProductLabelRepository extends AbstractRepository implements ProductLabelRepositoryInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelCollectionTransfer
+     */
+    public function getProductLabelCollection(
+        ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+    ): ProductLabelCollectionTransfer {
+        $productLabelCollectionTransfer = new ProductLabelCollectionTransfer();
+        $productLabelQuery = $this->getFactory()->createProductLabelQuery();
+
+        $paginationTransfer = $productLabelCriteriaTransfer->getPagination();
+        if ($paginationTransfer) {
+            $productLabelQuery = $this->applyProductLabelPagination($productLabelQuery, $paginationTransfer);
+            $productLabelCollectionTransfer->setPagination($paginationTransfer);
+        }
+
+        $productLabelQuery = $this->applyProductLabelFilters($productLabelQuery, $productLabelCriteriaTransfer);
+        $productLabelQuery = $this->applyProductLabelSorting($productLabelQuery, $productLabelCriteriaTransfer);
+
+        $productLabelEntities = $productLabelQuery->find();
+        $productLabelEntitiesIndexedByProductLabelIds = $this->indexProductLabelEntitiesByProductLabelIds($productLabelEntities);
+
+        $this->expandProductLabelWithProductLabelLocalizedAttributes($productLabelEntitiesIndexedByProductLabelIds, $productLabelCriteriaTransfer);
+        $this->expandProductLabelWithProductLabelProductAbstracts($productLabelEntitiesIndexedByProductLabelIds, $productLabelCriteriaTransfer);
+
+        return $this->getFactory()
+            ->createProductLabelMapper()
+            ->mapProductLabelEntitiesToProductLabelCollectionTransfer(
+                $productLabelEntities,
+                $productLabelCollectionTransfer
+            );
+    }
+
+    /**
+     * @param \Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery $productLabelQuery
+     * @param \Generated\Shared\Transfer\PaginationTransfer $paginationTransfer
+     *
+     * @return \Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery
+     */
+    protected function applyProductLabelPagination(
+        SpyProductLabelQuery $productLabelQuery,
+        PaginationTransfer $paginationTransfer
+    ): SpyProductLabelQuery {
+        $paginationTransfer->setNbResults($productLabelQuery->count());
+
+        if ($paginationTransfer->getLimit() !== null && $paginationTransfer->getOffset() !== null) {
+            return $productLabelQuery
+                ->limit($paginationTransfer->getLimit())
+                ->offset($paginationTransfer->getOffset());
+        }
+
+        return $productLabelQuery;
+    }
+
+
+    /**
+     * @param \Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery $productLabelQuery
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return \Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery
+     */
+    protected function applyProductLabelFilters(
+        SpyProductLabelQuery $productLabelQuery,
+        ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+    ): SpyProductLabelQuery {
+        if ($productLabelCriteriaTransfer->getProductAbstractIds()) {
+            $productLabelQuery->useSpyProductLabelProductAbstractQuery()
+                ->filterByFkProductAbstract_In($productLabelCriteriaTransfer->getProductAbstractIds())
+                ->endUse();
+        }
+
+        if ($productLabelCriteriaTransfer->getIsActive()) {
+            $productLabelQuery->filterByIsActive(true)
+                ->filterByValidFrom('now', Criteria::LESS_EQUAL)
+                ->_or()
+                ->filterByValidFrom(null, Criteria::ISNULL)
+                ->filterByValidTo('now', Criteria::GREATER_EQUAL)
+                ->_or()
+                ->filterByValidTo(null, Criteria::ISNULL);
+        }
+
+        return $productLabelQuery;
+    }
+
+    /**
+     * @param \Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery $productLabelQuery
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return \Orm\Zed\ProductLabel\Persistence\SpyProductLabelQuery
+     */
+    protected function applyProductLabelSorting(
+        SpyProductLabelQuery $productLabelQuery,
+        ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+    ): SpyProductLabelQuery {
+        $sortCollection = $productLabelCriteriaTransfer->getSortCollection();
+        foreach ($sortCollection as $sortTransfer) {
+            $productLabelQuery->orderBy(
+                $sortTransfer->getFieldOrFail(),
+                $sortTransfer->getIsAscending() ? Criteria::ASC : Criteria::DESC
+            );
+        }
+
+        return $productLabelQuery;
+    }
+
+    /**
+     * @param \Propel\Runtime\Collection\ObjectCollection<\Orm\Zed\ProductLabel\Persistence\SpyProductLabel> $productLabelEntities
+     *
+     * @return array<int, \Orm\Zed\ProductLabel\Persistence\SpyProductLabel>
+     */
+    protected function indexProductLabelEntitiesByProductLabelIds(ObjectCollection $productLabelEntities): array
+    {
+        $productLabelEntitiesIndexedByProductLabelIds = [];
+        foreach ($productLabelEntities as $productLabelEntity) {
+            $productLabelEntitiesIndexedByProductLabelIds[$productLabelEntity->getIdProductLabel()] = $productLabelEntity;
+        }
+
+        return $productLabelEntitiesIndexedByProductLabelIds;
+    }
+
+    /**
+     * @param array<int, \Orm\Zed\ProductLabel\Persistence\SpyProductLabel> $productLabelEntitiesIndexedByProductLabelIds
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return array<int, \Orm\Zed\ProductLabel\Persistence\SpyProductLabel>
+     */
+    protected function expandProductLabelWithProductLabelLocalizedAttributes(
+        array $productLabelEntitiesIndexedByProductLabelIds,
+        ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+    ): array {
+        foreach ($productLabelEntitiesIndexedByProductLabelIds as $productLabelEntity) {
+            $productLabelEntity->initSpyProductLabelLocalizedAttributess(false);
+        }
+
+        if (!$productLabelCriteriaTransfer->getWithProductLabelLocalizedAttributes()) {
+            return $productLabelEntitiesIndexedByProductLabelIds;
+        }
+
+        $productLabelLocalizedAttributeEntities = $this->getFactory()
+            ->createLocalizedAttributesQuery()
+            ->leftJoinWithSpyLocale()
+            ->leftJoinWithSpyProductLabel()
+            ->filterByFkProductLabel_In(array_keys($productLabelEntitiesIndexedByProductLabelIds))
+            ->find();
+
+        foreach ($productLabelLocalizedAttributeEntities as $productLabelLocalizedAttributeEntity) {
+            $productLabelId = $productLabelLocalizedAttributeEntity->getFkProductLabel();
+            if (!isset($productLabelEntitiesIndexedByProductLabelIds[$productLabelId])) {
+                continue;
+            }
+
+            $productLabelEntitiesIndexedByProductLabelIds[$productLabelId]->addSpyProductLabelLocalizedAttributes($productLabelLocalizedAttributeEntity);
+        }
+
+        return $productLabelEntitiesIndexedByProductLabelIds;
+    }
+
+    /**
+     * @param array<int, \Orm\Zed\ProductLabel\Persistence\SpyProductLabel> $productLabelEntitiesIndexedByProductLabelIds
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return array<int, \Orm\Zed\ProductLabel\Persistence\SpyProductLabel>
+     */
+    protected function expandProductLabelWithProductLabelProductAbstracts(
+        array $productLabelEntitiesIndexedByProductLabelIds,
+        ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+    ): array {
+        foreach ($productLabelEntitiesIndexedByProductLabelIds as $productLabelEntity) {
+            $productLabelEntity->initSpyProductLabelProductAbstracts(false);
+        }
+
+        if (!$productLabelCriteriaTransfer->getWithProductLabelProductAbstracts()) {
+            return $productLabelEntitiesIndexedByProductLabelIds;
+        }
+
+        $productLabelProductAbstractEntities = $this->getFactory()
+            ->createProductRelationQuery()
+            ->filterByFkProductLabel_In(array_keys($productLabelEntitiesIndexedByProductLabelIds))
+            ->find();
+
+        foreach ($productLabelProductAbstractEntities as $productLabelProductAbstractEntity) {
+            $productLabelId = $productLabelProductAbstractEntity->getFkProductLabel();
+            if (!isset($productLabelEntitiesIndexedByProductLabelIds[$productLabelId])) {
+                continue;
+            }
+
+            $productLabelEntitiesIndexedByProductLabelIds[$productLabelId]->addSpyProductLabelProductAbstract($productLabelProductAbstractEntity);
+        }
+
+        return $productLabelEntitiesIndexedByProductLabelIds;
+    }
+}

--- a/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelRepositoryInterface.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/ProductLabelRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductLabel\Persistence;
+
+use Generated\Shared\Transfer\ProductLabelCollectionTransfer;
+use Generated\Shared\Transfer\ProductLabelCriteriaTransfer;
+
+interface ProductLabelRepositoryInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\ProductLabelCriteriaTransfer $productLabelCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductLabelCollectionTransfer
+     */
+    public function getProductLabelCollection(ProductLabelCriteriaTransfer $productLabelCriteriaTransfer): ProductLabelCollectionTransfer;
+}

--- a/src/Spryker/Zed/ProductLabel/Persistence/Propel/AbstractSpyProductLabel.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Propel/AbstractSpyProductLabel.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductLabel\Persistence\Propel;
+
+use Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabel;
+
+/**
+ * Skeleton subclass for representing a row from the 'spy_product_label' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements. This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+abstract class AbstractSpyProductLabel extends SpyProductLabel
+{
+}

--- a/src/Spryker/Zed/ProductLabel/Persistence/Propel/AbstractSpyProductLabelLocalizedAttributes.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Propel/AbstractSpyProductLabelLocalizedAttributes.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductLabel\Persistence\Propel;
+
+use Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabelLocalizedAttributes;
+
+/**
+ * Skeleton subclass for representing a row from the 'spy_product_label_localized_attributes' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements. This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+abstract class AbstractSpyProductLabelLocalizedAttributes extends SpyProductLabelLocalizedAttributes
+{
+}

--- a/src/Spryker/Zed/ProductLabel/Persistence/Propel/AbstractSpyProductLabelLocalizedAttributesQuery.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Propel/AbstractSpyProductLabelLocalizedAttributesQuery.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductLabel\Persistence\Propel;
+
+use Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabelLocalizedAttributesQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'spy_product_label_localized_attributes' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements. This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+abstract class AbstractSpyProductLabelLocalizedAttributesQuery extends SpyProductLabelLocalizedAttributesQuery
+{
+}

--- a/src/Spryker/Zed/ProductLabel/Persistence/Propel/AbstractSpyProductLabelProductAbstract.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Propel/AbstractSpyProductLabelProductAbstract.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductLabel\Persistence\Propel;
+
+use Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabelProductAbstract;
+
+/**
+ * Skeleton subclass for representing a row from the 'spy_product_label_product_abstract' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements. This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+abstract class AbstractSpyProductLabelProductAbstract extends SpyProductLabelProductAbstract
+{
+}

--- a/src/Spryker/Zed/ProductLabel/Persistence/Propel/AbstractSpyProductLabelProductAbstractQuery.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Propel/AbstractSpyProductLabelProductAbstractQuery.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductLabel\Persistence\Propel;
+
+use Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabelProductAbstractQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'spy_product_label_product_abstract' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements. This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+abstract class AbstractSpyProductLabelProductAbstractQuery extends SpyProductLabelProductAbstractQuery
+{
+}

--- a/src/Spryker/Zed/ProductLabel/Persistence/Propel/AbstractSpyProductLabelQuery.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Propel/AbstractSpyProductLabelQuery.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductLabel\Persistence\Propel;
+
+use Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabelQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'spy_product_label' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements. This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+abstract class AbstractSpyProductLabelQuery extends SpyProductLabelQuery
+{
+}

--- a/src/Spryker/Zed/ProductLabel/Persistence/Propel/SpyProductLabel.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Propel/SpyProductLabel.php
@@ -9,6 +9,9 @@ namespace Spryker\Zed\ProductLabel\Persistence\Propel;
 
 use Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabel as BaseSpyProductLabel;
 
+/**
+ * @deprecated Please use AbstractSpyProductLabel instead.
+ */
 class SpyProductLabel extends BaseSpyProductLabel
 {
 }

--- a/src/Spryker/Zed/ProductLabel/Persistence/Propel/SpyProductLabelLocalizedAttributes.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Propel/SpyProductLabelLocalizedAttributes.php
@@ -9,6 +9,9 @@ namespace Spryker\Zed\ProductLabel\Persistence\Propel;
 
 use Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabelLocalizedAttributes as BaseSpyProductLabelLocalizedAttributes;
 
+/**
+ * @deprecated Please use AbstractSpyProductLabelLocalizedAttributes instead.
+ */
 class SpyProductLabelLocalizedAttributes extends BaseSpyProductLabelLocalizedAttributes
 {
 }

--- a/src/Spryker/Zed/ProductLabel/Persistence/Propel/SpyProductLabelLocalizedAttributesQuery.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Propel/SpyProductLabelLocalizedAttributesQuery.php
@@ -9,6 +9,9 @@ namespace Spryker\Zed\ProductLabel\Persistence\Propel;
 
 use Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabelLocalizedAttributesQuery as BaseSpyProductLabelLocalizedAttributesQuery;
 
+/**
+ * @deprecated Please use AbstractSpyProductLabelLocalizedAttributesQuery instead.
+ */
 class SpyProductLabelLocalizedAttributesQuery extends BaseSpyProductLabelLocalizedAttributesQuery
 {
 }

--- a/src/Spryker/Zed/ProductLabel/Persistence/Propel/SpyProductLabelProductAbstract.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Propel/SpyProductLabelProductAbstract.php
@@ -9,6 +9,9 @@ namespace Spryker\Zed\ProductLabel\Persistence\Propel;
 
 use Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabelProductAbstract as BaseSpyProductLabelProductAbstract;
 
+/**
+ * @deprecated Please use AbstractSpyProductLabelProductAbstract instead.
+ */
 class SpyProductLabelProductAbstract extends BaseSpyProductLabelProductAbstract
 {
 }

--- a/src/Spryker/Zed/ProductLabel/Persistence/Propel/SpyProductLabelProductAbstractQuery.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Propel/SpyProductLabelProductAbstractQuery.php
@@ -7,8 +7,11 @@
 
 namespace Spryker\Zed\ProductLabel\Persistence\Propel;
 
-use Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabelProductAbstractQuery as BaseSpyProductLabelProductAbstractQuery;
+use Spryker\Zed\ProductLabel\Persistence\Propel\AbstractSpyProductLabelProductAbstractQuery as BaseSpyProductLabelProductAbstractQuery;
 
+/**
+ * @deprecated Please use AbstractSpyProductLabelProductAbstractQuery instead.
+ */
 class SpyProductLabelProductAbstractQuery extends BaseSpyProductLabelProductAbstractQuery
 {
 }

--- a/src/Spryker/Zed/ProductLabel/Persistence/Propel/SpyProductLabelQuery.php
+++ b/src/Spryker/Zed/ProductLabel/Persistence/Propel/SpyProductLabelQuery.php
@@ -7,8 +7,11 @@
 
 namespace Spryker\Zed\ProductLabel\Persistence\Propel;
 
-use Orm\Zed\ProductLabel\Persistence\Base\SpyProductLabelQuery as BaseSpyProductLabelQuery;
+use Spryker\Zed\ProductLabel\Persistence\Propel\AbstractSpyProductLabelQuery as BaseSpyProductLabelQuery;
 
+/**
+ * @deprecated Please use AbstractSpyProductLabelQuery instead.
+ */
 class SpyProductLabelQuery extends BaseSpyProductLabelQuery
 {
 }


### PR DESCRIPTION
Branch: backport/1.2.0
Ticket: https://spryker.atlassian.net/browse/SUPESC-667
Version: 1.2.0

#### Release Table

   Module                | Release Type         | Constraint Updates         
   :--------------------- | :------------------------ | :---------------------  |
   ProductLabel  | minor                 |                        |

-----------------------------------------

#### Module ProductLabel

##### Change log

Improvements

- Introduced `ProductLabelFacade::getProductLabelCollection()` to fetch product labels from Persistence.
- Introduced `ProductLabelProductAbstract` transfer. 
- Introduced `ProductLabelCriteria` transfer. 
- Introduced `ProductLabelCollection` transfer. 
- Introduced `ProductLabelConditions` transfer. 
- Introduced `Pagination` transfer.  
- Introduced `Locale` transfer. 
- Introduced `Sort` transfer.
- Introduced `ProductLabel.productLabelProductAbstracts` transfer field.
- Increased `Kernel` dependency version.
- Added `Transfer` module to dependencies.

Deprecations

- Deprecated `SpyProductLabel`.
- Deprecated `SpyProductLabelLocalizedAttributes`.
- Deprecated `SpyProductLabelLocalizedAttributesQuery`.
- Deprecated `SpyProductLabelProductAbstract`.
- Deprecated `SpyProductLabelProductAbstractQuery`.
- Deprecated `SpyProductLabelQuery`.
